### PR TITLE
Change REP macro to long long i as opposed to int i

### DIFF
--- a/template.cpp
+++ b/template.cpp
@@ -16,7 +16,7 @@
 #define all(x) begin(x), end(x)
 #define rall(x) rbegin(x), rend(x)
 #define sz(x) (int)x.size()
-#define REP(i, a) for (int i = 0; i < a; i++)
+#define REP(i, a) for (long long i = 0; i < a; i++)
 #define pii pair<int, int>;
 #define setprf(x) setprecision(x) << fixed
 #define setpr(x) setprecision(x)


### PR DESCRIPTION
Minor change, but takes care of edge cases where loop function needs to be used for precomputing powers and i*i int causes overflow.